### PR TITLE
feat(shop): Add shop offers for all town hall levels.

### DIFF
--- a/css/pages/_income.scss
+++ b/css/pages/_income.scss
@@ -119,6 +119,10 @@
         grid-template-columns: auto 1fr 1fr;
     }
 
+    &#shop-offer-checkboxes {
+        margin-top: 0px;
+    }
+
     .offer-grid-header {
         display: contents;
 

--- a/js/data/allIncomeData.js
+++ b/js/data/allIncomeData.js
@@ -46,8 +46,8 @@ export const shopOfferData = {
             maxPacks: 2,
         },
     },
-    TH15_Set: {
-        townHallLevel: 15,
+    TH14_Set: {
+        townHallLevel: 14,
         shiny_large: {
             shiny: 12000,
             glowy: 0,
@@ -74,6 +74,61 @@ export const shopOfferData = {
             glowy: 0,
             starry: 0,
             baseCostUSD: 5.99,
+            maxPacks: 2,
+        },
+    },
+    TH11_Set: {
+        townHallLevel: 11,
+        shiny_large: {
+            shiny: 12000,
+            glowy: 0,
+            starry: 0,
+            baseCostUSD: 9.99,
+            maxPacks: 2,
+        },
+        glowy: {
+            shiny: 0,
+            glowy: 500,
+            starry: 0,
+            baseCostUSD: 4.99,
+            maxPacks: 2,
+        },
+        starry: {
+            shiny: 0,
+            glowy: 0,
+            starry: 55,
+            baseCostUSD: 4.99,
+            maxPacks: 2,
+        },
+        shiny_small: {
+            shiny: 4000,
+            glowy: 0,
+            starry: 0,
+            baseCostUSD: 4.99,
+            maxPacks: 2,
+        },
+    },
+    TH8_Set: {
+        townHallLevel: 8,
+        glowy: {
+            shiny: 0,
+            glowy: 400,
+            starry: 0,
+            baseCostUSD: 3.99,
+            maxPacks: 2,
+        },
+        starry: {
+            shiny: 0,
+            glowy: 0,
+            starry: 40,
+            baseCostUSD: 3.99,
+            maxPacks: 2,
+        },
+        shiny_small: {
+            shiny: 3000,
+            glowy: 0,
+            starry: 0,
+            baseCostUSD: 3.99,
             maxPacks: 2,
         },
     },

--- a/js/data/currencyData.js
+++ b/js/data/currencyData.js
@@ -16,13 +16,18 @@ export const currencyConversionRates = {
         "GBP": 0.99,
         "INR": 89.00,
     },
+    "3.99": {
+        "EUR": 4.99,
+        "GBP": 3.99,
+        "INR": 349.00,
+    },
     "4.99": {
         "EUR": 5.99,
         "GBP": 4.99,
         "INR": 449.00,
     },
     "5.99": {
-        "EUR": 7.19,
+        "EUR": 7.49,
         "GBP": 5.99,
         "INR": 539.00,
     },

--- a/js/data/incomeChipData.js
+++ b/js/data/incomeChipData.js
@@ -7,7 +7,7 @@ export const incomeData = {
         isSingleEvent: true,
         schedule: {
             type: 'monthly',
-            dateStart: 24,
+            dateStart: 26,
             dateEnd: 28,
         },
         getIncome: (state) => state.derived.incomeSources.shopOffers?.monthly || { shiny: 0, glowy: 0, starry: 0 },


### PR DESCRIPTION
This commit introduces shop offer data for Town Hall levels 8+, 11+, and 14+. It also includes the corresponding currency conversions for the new offers and a minor styling update for the shop offer section.

Fixes #14 