### PR TITLE
feat(income): Added 4x star bonus event calculation

### DIFF
--- a/index.html
+++ b/index.html
@@ -340,6 +340,13 @@
                             <select id="inc-star-bonus-league-select" class="dropdown-style updatable">
                             </select>
                         </div>
+                        <div class="input-group-flex">
+                            <label for="inc-star-bonus-4x-toggle" data-i18n="bimonthly_4x_event">Bimonthly 4x Event:</label>
+                            <select id="inc-star-bonus-4x-toggle" class="dropdown-style updatable">
+                                <option value="false" data-i18n="no">No</option>
+                                <option value="true" data-i18n="yes">Yes</option>
+                            </select>
+                        </div>
                     </div>
                     <div class="timeframe-income">
                         <div class="four-col-grid">

--- a/js/components/income/starBonusSelector.js
+++ b/js/components/income/starBonusSelector.js
@@ -53,22 +53,35 @@ function renderStarBonusSelectorContent() {
 
 export function initializeStarBonusSelector() {
     const selectElement = dom.income?.starBonus?.league;
-    if (!selectElement) return;
-
-    renderStarBonusSelectorContent();
-
-    selectElement.addEventListener('change', (e) => {
-        handleStateUpdate(() => {
-            state.income.starBonusLeague = parseInt(e.target.value, 10);
+    if (selectElement) {
+        selectElement.addEventListener('change', (e) => {
+            handleStateUpdate(() => {
+                state.income.starBonus.league = parseInt(e.target.value, 10);
+            });
         });
-    });
+    }
+
+    const toggleElement = dom.income?.starBonus?.is4xEnabled;
+    if (toggleElement) {
+        toggleElement.addEventListener('change', (e) => {
+            handleStateUpdate(() => {
+                state.income.starBonus.is4xEnabled = e.target.value === 'true';
+            });
+        });
+    }
 
     document.addEventListener('languageChanged', renderStarBonusSelectorContent);
+    renderStarBonusSelectorContent();
 }
 
-export function renderStarBonusSelector(selectedLeague) {
+export function renderStarBonusControls(incomeState) {
     const selectElement = dom.income?.starBonus?.league;
     if (selectElement) {
-        selectElement.value = selectedLeague;
+        selectElement.value = incomeState.starBonus.league;
+    }
+
+    const toggleElement = dom.income?.starBonus?.is4xEnabled;
+    if (toggleElement) {
+        toggleElement.value = incomeState.starBonus.is4xEnabled;
     }
 }

--- a/js/core/calculator.js
+++ b/js/core/calculator.js
@@ -18,7 +18,7 @@ export function recalculateAll(state) {
     const eventTraderIncome = calculateEventTraderIncome(state.income.eventTrader, eventPassIncome?.availableMedals);
 
     const incomeSources = {
-        starBonus: calculateStarBonusIncome(state.income.starBonusLeague),
+        starBonus: calculateStarBonusIncome(state.income.starBonus.league, state.income.starBonus.is4xEnabled),
         clanWar: calculateClanWarIncome(state.income.clanWar),
         cwl: calculateCwlIncome(state.income.cwl),
         raidMedalTrader: calculateRaidMedalTraderIncome(state.income.raidMedals),

--- a/js/core/renderer.js
+++ b/js/core/renderer.js
@@ -5,7 +5,7 @@ import { renderHeroCards } from '../components/equipment/heroCardDisplay.js';
 import { renderStorageInputs } from '../components/equipment/storageInputs.js';
 import { renderPlayerDropdown } from '../components/player/playerDropdown.js';
 
-import { renderStarBonusSelector } from '../components/income/starBonusSelector.js';
+import { renderStarBonusControls } from '../components/income/starBonusSelector.js';
 import { renderClanWarInputs } from '../components/income/clanWarInputs.js';
 import { renderCwlInputs } from '../components/income/cwlInputs.js';
 import { renderEventPassInputs } from '../components/income/eventPassInputs.js';
@@ -43,7 +43,7 @@ export function renderApp(state) {
     renderStorageInputs(state.storedOres);
     renderPlayerDropdown();
 
-    renderStarBonusSelector(state.income.starBonusLeague);
+    renderStarBonusControls(state.income);
     renderClanWarInputs(state.income.clanWar);
     renderCwlInputs(state.income.cwl);
     renderEventPassInputs(state.income.eventPass);
@@ -58,7 +58,7 @@ export function renderApp(state) {
     renderRemainingTime(state.derived.remainingTime);
 
     const starBonusIncome = incomeSources.starBonus || {};
-    renderStarBonusDisplay(starBonusIncome, state.income.starBonusLeague, state.playerData, timeframe);
+    renderStarBonusDisplay(starBonusIncome, state.income.starBonus.league, state.playerData, timeframe);
 
     const clanWarIncome = incomeSources.clanWar || {};
     renderClanWarHomeDisplay(clanWarIncome[timeframe] || {}, state.income.clanWar, state.playerData);

--- a/js/core/state.js
+++ b/js/core/state.js
@@ -42,7 +42,10 @@ export function getDefaultState() {
         heroes: initializeHeroesState(),
         storedOres: { shiny: 0, glowy: 0, starry: 0 },
         income: {
-            starBonusLeague: 105000000,
+            starBonus: {
+                league: 105000000,
+                is4xEnabled: false,
+            },
             shopOffers: {
                 selectedSet: 'none',
                 sets: { TH16_Set: {}, TH15_Set: {} },
@@ -87,7 +90,10 @@ export function getDefaultState() {
             heroes: initializeHeroesState(),
             storedOres: { shiny: 0, glowy: 0, starry: 0 },
             income: {
-                starBonusLeague: 105000000,
+                starBonus: {
+                    league: 105000000,
+                    is4xStarBonusAverageEnabled: false,
+                },
                 shopOffers: {
                     selectedSet: 'none',
                     sets: { TH16_Set: {}, TH15_Set: {} },
@@ -176,7 +182,10 @@ export function getDefaultPlayerState() {
             heroes: initializeHeroesState(),
             storedOres: { shiny: 0, glowy: 0, starry: 0 },
             income: {
-                starBonusLeague: 105000000,
+                starBonus: {
+                    league: 105000000,
+                    is4xEnabled: false,
+                },
                 shopOffers: {
                     selectedSet: 'none',
                     sets: { TH16_Set: {}, TH15_Set: {} },
@@ -495,9 +504,9 @@ export function initializeState(savedState) {
                 activePlayerData.income
             );
 
-            const leagueExists = leagueTiers.items.some(l => l.id === state.income.starBonusLeague);
+            const leagueExists = leagueTiers.items.some(l => l.id === state.income.starBonus.league);
             if (!leagueExists) {
-                state.income.starBonusLeague = 105000000; // Unranked
+                state.income.starBonus.league = 105000000; // Unranked
             }
             Object.assign(
                 state.planner,

--- a/js/dom/incomeDom.js
+++ b/js/dom/incomeDom.js
@@ -114,6 +114,7 @@ export function getIncomeDOMElements() {
         },
         starBonus: {
             league: document.getElementById('inc-star-bonus-league-select'),
+            is4xEnabled: document.getElementById('inc-star-bonus-4x-toggle'),
             display: {
                 daily: {
                     shiny: document.getElementById('inc-star-bonus-shiny-daily-value'),

--- a/js/i18n/de.json
+++ b/js/i18n/de.json
@@ -89,6 +89,7 @@
     "per_hit_colon": "Pro Angriff:",
     "common_colon": "Gewöhnlich:",
     "epic_colon": "Episch:",
+    "bimonthly_4x_event": "Zweimonatlich 4x Event:",
     "language": "Sprache:",
     "english": "Englisch",
     "german": "Deutsch",

--- a/js/i18n/en.json
+++ b/js/i18n/en.json
@@ -97,6 +97,7 @@
     "per_hit_colon": "Per Hit:",
     "common_colon": "Common:",
     "epic_colon": "Epic:",
+    "bimonthly_4x_event": "Bimonthly 4x Event:",
 
     "language": "Language:",
     "english": "English",

--- a/js/incomeCalculations/starBonusIncome.js
+++ b/js/incomeCalculations/starBonusIncome.js
@@ -1,12 +1,20 @@
 import { starBonusData } from "../data/appData.js";
 import { DAYS_IN_WEEK, DAYS_IN_MONTH, MONTHS_IN_BIMONTH } from "../data/timeConstants.js";
 
-export function calculateStarBonusIncome(selectedLeague) {
+export function calculateStarBonusIncome(selectedLeague, is4xEnabled) {
     const leagueData = starBonusData.find(data => data.league === parseInt(selectedLeague)) || starBonusData[0];
+
+    let multiplier = 1;
+    if (is4xEnabled) {
+        const eventBonusInstances = 2.5;
+        const daysInMonth = DAYS_IN_MONTH;
+        multiplier = ((eventBonusInstances * 3) + (daysInMonth - eventBonusInstances) * 1) / daysInMonth;
+    }
+
     const daily = {
-        shiny: leagueData.shiny || 0,
-        glowy: leagueData.glowy || 0,
-        starry: leagueData.starry || 0,
+        shiny: (leagueData.shiny || 0) * multiplier,
+        glowy: (leagueData.glowy || 0) * multiplier,
+        starry: (leagueData.starry || 0) * multiplier,
     };
     const weekly = {
         shiny: daily.shiny * DAYS_IN_WEEK,

--- a/js/services/serverResponseHandler.js
+++ b/js/services/serverResponseHandler.js
@@ -99,9 +99,9 @@ export function processPlayerDataResponse(playerData) {
     if (playerData.leagueTier?.id) {
         const leagueExists = leagueTiers.items.some(l => l.id === playerData.leagueTier.id);
         if (leagueExists) {
-            newPlayerState.income.starBonusLeague = playerData.leagueTier.id;
+            newPlayerState.income.starBonus.league = playerData.leagueTier.id;
         } else {
-            newPlayerState.income.starBonusLeague = 105000000; // Unranked
+            newPlayerState.income.starBonus.league = 105000000; // Unranked
         }
     }
 


### PR DESCRIPTION
Added a dropdown in the income tab's star bonus card to enable or disable the 4x star bonus calculation.

<img width="1168" height="962" alt="image" src="https://github.com/user-attachments/assets/54623b3c-5cb2-42b8-a41e-096b55a39248" />


<img width="1180" height="974" alt="image" src="https://github.com/user-attachments/assets/37bdbf64-ace5-469c-b982-8faf0c7ce8e4" />
