### PR TITLE
feat(i18n): implement URL-based language routing and SSG pre-rendering

### DIFF
--- a/404.html
+++ b/404.html
@@ -237,6 +237,16 @@
                 }
             }
 
+            // Preserve language route on 404 links
+            const segments = window.location.pathname.split('/').filter(Boolean);
+            let lang = 'en';
+            if (segments.length > 0 && ['en', 'de', 'tr'].includes(segments[0].toLowerCase())) {
+                lang = segments[0].toLowerCase();
+            }
+            document.querySelectorAll('.back-link, .btn').forEach(link => {
+                link.href = `/${lang}/`;
+            });
+
             // Sync toggle button initial state
             updateTheme(getTheme());
 

--- a/index.html
+++ b/index.html
@@ -3,13 +3,18 @@
 
 <head>
     <meta charset="UTF-8">
+    <base href="/">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title data-i18n="app.title">Clash of Clans Ore Calculator &amp; Equipment Planner | OreCalc</title>
     <meta name="description"
         content="The ultimate Clash of Clans Ore Calculator &amp; Hero Equipment Upgrade Planner. Forecast Shiny, Glowy &amp; Starry ore income, schedule upgrades, and optimize progress with OreCalc.">
     <link rel="icon" href="assets/favicon.png" type="image/x-icon">
     <link rel="manifest" href="manifest.json">
-    <link rel="canonical" href="https://orecalc.tech/">
+    <link rel="canonical" href="https://orecalc.tech/en/">
+    <link rel="alternate" hreflang="en" href="https://orecalc.tech/en/">
+    <link rel="alternate" hreflang="de" href="https://orecalc.tech/de/">
+    <link rel="alternate" hreflang="tr" href="https://orecalc.tech/tr/">
+    <link rel="alternate" hreflang="x-default" href="https://orecalc.tech/en/">
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">

--- a/js/app.js
+++ b/js/app.js
@@ -7,6 +7,7 @@ import { saveState, loadState, resetState, setResettingState } from './core/loca
 import { renderApp } from './core/renderer.js';
 import { recalculateAll } from './core/calculator.js';
 import { registerStateUpdateCallback, handleStateUpdate } from './core/stateManager.js';
+import { detectLanguage, syncLanguageUrl, getLanguageFromPath, isValidRoute } from './core/languageRouter.js';
 
 import { initializeHeader } from './components/layout/header.js';
 import { initializeTabs } from './components/layout/tabs.js';
@@ -228,8 +229,12 @@ export function updateUIWithTranslations(isInitialLoad = false) {
             }
         }
 
+        if (key === 'settings.bugReportInfo') {
+            args.link = '<a href="https://github.com/abhis-s/oreCalc/issues" target="_blank" rel="noopener noreferrer" class="theme-link">GitHub Issues</a>';
+        }
+
         if (key === 'settings.bugReportPrivacyInfo') {
-            const privacyText = translate('settings.privacyPolicyText');
+            const privacyText = translate('settings.privacyPolicyText') || 'Privacy Policy';
             args.link = `<a href="#" id="bug-report-privacy-link" class="theme-link">${privacyText}</a>`;
         }
 
@@ -605,8 +610,9 @@ if (!window.__DOM_CONTENT_LOADED_REGISTERED__) {
 
     // Redirect invalid pathnames (404 fallback routing)
     const pathName = window.location.pathname;
-    if (pathName !== '/' && pathName !== '/index.html' && pathName !== '/404') {
-        window.location.href = '/404';
+    if (!isValidRoute(pathName)) {
+        const currentLang = getLanguageFromPath() || 'en';
+        window.location.href = `/${currentLang}/404`;
         return;
     }
 
@@ -693,11 +699,14 @@ if (!window.__DOM_CONTENT_LOADED_REGISTERED__) {
 
 
     // 1. PERFORM MINIMAL BACKGROUND INIT IMMEDIATELY
-    // Only load core translations and non-DOM state
+    const initialLang = detectLanguage();
+    state.uiSettings.language = initialLang;
+    syncLanguageUrl(initialLang, true);
+
     (async () => {
         await loadTranslations('en');
-        if (state.uiSettings.language && state.uiSettings.language !== 'en' && state.uiSettings.language !== 'auto') {
-            await loadTranslations(state.uiSettings.language);
+        if (initialLang !== 'en') {
+            await loadTranslations(initialLang);
         }
     })();
 
@@ -705,16 +714,7 @@ if (!window.__DOM_CONTENT_LOADED_REGISTERED__) {
     // This gives the CPU 2.3s of complete silence to perform the 60fps cinematic sequence.
     // The "hiccup" of rendering happens at 2.3s while the screen is covered by a solid color.
     setTimeout(async () => {
-        if (!state.uiSettings.language || state.uiSettings.language === 'auto') {
-            const userLangs = navigator.languages || [navigator.language];
-            let detectedLang = 'en';
-
-            for (const l of userLangs) {
-                if (l.startsWith('de')) { detectedLang = 'de'; break; }
-                if (l.startsWith('tr')) { detectedLang = 'tr'; break; }
-            }
-            state.uiSettings.language = detectedLang;
-        }
+        state.uiSettings.language = initialLang;
 
         if (!state.uiSettings.currency || !state.uiSettings.currency.code) {
             const userLangs = navigator.languages || [navigator.language];

--- a/js/components/appSettings/appSettings.js
+++ b/js/components/appSettings/appSettings.js
@@ -4,6 +4,7 @@ import { removePlayerTag, saveState } from '../../core/localStorageManager.js';
 import { renderApp } from '../../core/renderer.js';
 import { state, EFFECTIVE_DATE_TERMS, EFFECTIVE_DATE_PRIVACY } from '../../core/state.js';
 import { showToast } from '../../ui/toast.js';
+import { syncLanguageUrl } from '../../core/languageRouter.js';
 
 import { addCurrencyValidation } from '../../utils/inputValidator.js';
 import { currencyData, priceTierRegistry, languagesData, transparencyData, developmentSupportData } from '../../data/appData.js';
@@ -1627,6 +1628,7 @@ export function initializeAppSettings() {
 
             handleStateUpdate(() => {
                 state.uiSettings.language = newLanguage;
+                syncLanguageUrl(newLanguage, false);
             });
             
             document.dispatchEvent(new CustomEvent('app:translate'));

--- a/js/components/income/prospectorDisplay.js
+++ b/js/components/income/prospectorDisplay.js
@@ -1,6 +1,7 @@
 import { dom } from '../../dom/domElements.js';
 import { state } from '../../core/state.js';
 import { handleStateUpdate } from '../../app.js';
+import { getLanguageFromPath } from '../../core/languageRouter.js';
 
 import { convertOres, getStepValue, findOptimalConversionSchedule } from '../../incomeCalculations/prospectorManager.js';
 
@@ -398,7 +399,8 @@ function updateProspectorTip() {
             const currentTab = state.activeTab;
             if (currentTab !== 'planner-tab') {
                 setAnimateNextRender('all');
-                history.pushState(null, '', '#planner');
+                const currentLang = getLanguageFromPath() || state.uiSettings?.language || 'en';
+                history.pushState(null, '', `/${currentLang}/#planner`);
                 state.activeTab = 'planner-tab';
                 renderApp(state);
             }

--- a/js/components/layout/navigation.js
+++ b/js/components/layout/navigation.js
@@ -1,6 +1,7 @@
 import { dom } from '../../dom/domElements.js';
 import { renderApp } from '../../core/renderer.js';
 import { state } from '../../core/state.js';
+import { getLanguageFromPath } from '../../core/languageRouter.js';
 
 function toggleNavigationDrawer() {
     const isOpen = dom.drawer.drawer.classList.toggle('open');
@@ -65,7 +66,9 @@ export function initializeNavigation() {
                 }
 
                 const tabId = `${tab.dataset.tab}-tab`;
-                history.pushState(null, '', `#${tab.dataset.tab}`);
+                const currentLang = getLanguageFromPath() || state.uiSettings?.language || 'en';
+                const hash = tab.dataset.tab === 'home' ? '' : `#${tab.dataset.tab}`;
+                history.pushState(null, '', `/${currentLang}/${hash}`);
                 state.activeTab = tabId;
                 renderApp(state);
                 closeNavigationDrawer();

--- a/js/components/layout/tabs.js
+++ b/js/components/layout/tabs.js
@@ -3,11 +3,11 @@ import { renderApp } from '../../core/renderer.js';
 import { state } from '../../core/state.js';
 
 import { navigationRegistry } from '../../data/navigationRegistry.js';
+import { getLanguageFromPath } from '../../core/languageRouter.js';
 
 import { closeFabMenu } from '../fab/fab.js';
 import { openStoredOresModal } from '../planner/priorityListModal.js';
 import { setAnimateNextRender } from '../planner/calendar.js';
-// import { repackCards } from '../../ui/cardLayoutManager.js';
 
 function checkPlannerTabStoredOres() {
     const storedOres = state.storedOres || {};
@@ -32,7 +32,8 @@ export function initializeTabs() {
     let initialTab = window.location.hash ? `${window.location.hash.substring(1)}-tab` : 'home-tab';
     
     if (!validTabs.includes(initialTab)) {
-        history.replaceState(null, '', window.location.pathname);
+        const currentLang = getLanguageFromPath() || state.uiSettings?.language || 'en';
+        history.replaceState(null, '', `/${currentLang}/`);
         initialTab = 'home-tab';
     }
     state.activeTab = initialTab;
@@ -48,7 +49,8 @@ export function initializeTabs() {
 
         const tabOrder = navigationRegistry.map(item => `${item.id}-tab`);
         if (!tabOrder.includes(tabId)) {
-            history.replaceState(null, '', window.location.pathname);
+            const currentLang = getLanguageFromPath() || state.uiSettings?.language || 'en';
+            history.replaceState(null, '', `/${currentLang}/`);
             tabId = 'home-tab';
         }
 
@@ -112,7 +114,9 @@ export function initializeTabs() {
                 }, 100);
             }
             
-            history.pushState(null, '', `#${button.dataset.tab}`);
+            const currentLang = getLanguageFromPath() || state.uiSettings?.language || 'en';
+            const targetUrl = button.dataset.tab === 'home' ? `/${currentLang}/` : `/${currentLang}/#${button.dataset.tab}`;
+            history.pushState(null, '', targetUrl);
             state.activeTab = tabId;
             renderApp(state);
         };

--- a/js/components/welcome/welcomeModal.js
+++ b/js/components/welcome/welcomeModal.js
@@ -4,6 +4,7 @@ import { handleStateUpdate, switchActivePlayer } from '../../core/stateManager.j
 import { loadAndProcessPlayerData, processPlayerDataResponse } from '../../services/serverResponseHandler.js';
 import { fetchPlayerData } from '../../services/apiService.js';
 import { translate, loadTranslations } from '../../i18n/translator.js';
+import { syncLanguageUrl } from '../../core/languageRouter.js';
 import { renderApp } from '../../core/renderer.js';
 import { validatePlayerTagInput } from '../../utils/playerTagValidator.js';
 import { openTermsOfUseModal, openPrivacyModal, openBugReportModal } from '../appSettings/appSettings.js';
@@ -713,6 +714,7 @@ export function initializeWelcomeModal() {
 
             handleStateUpdate(() => {
                 state.uiSettings.language = newLang;
+                syncLanguageUrl(newLang, false);
             });
 
             document.dispatchEvent(new CustomEvent('app:translate'));

--- a/js/core/languageRouter.js
+++ b/js/core/languageRouter.js
@@ -1,0 +1,106 @@
+import { state } from './state.js';
+
+export const SUPPORTED_LANGUAGES = ['en', 'de', 'tr'];
+
+/**
+ * Extracts a supported language code from the URL path.
+ * e.g., "/de/#home" -> "de", "/tr/planner" -> "tr", "/en" -> "en"
+ */
+export function getLanguageFromPath() {
+    const pathSegments = window.location.pathname.split('/').filter(Boolean);
+    if (pathSegments.length > 0 && SUPPORTED_LANGUAGES.includes(pathSegments[0].toLowerCase())) {
+        return pathSegments[0].toLowerCase();
+    }
+    return null;
+}
+
+/**
+ * Determines initial language based on:
+ * 1. URL Path (/en, /de, /tr)
+ * 2. Saved State / LocalStorage
+ * 3. Browser Navigator languages
+ * 4. Fallback 'en'
+ */
+export function detectLanguage() {
+    // 1. Path-based language taking highest precedence
+    const pathLang = getLanguageFromPath();
+    if (pathLang) return pathLang;
+
+    // 2. Saved preference in state or localStorage
+    const savedLang = state.uiSettings?.language || localStorage.getItem('oreCalc_language');
+    if (savedLang && SUPPORTED_LANGUAGES.includes(savedLang) && savedLang !== 'auto') {
+        return savedLang;
+    }
+
+    // 3. Browser navigator language
+    const userLangs = navigator.languages || [navigator.language || 'en'];
+    for (const l of userLangs) {
+        const prefix = l.toLowerCase().substring(0, 2);
+        if (SUPPORTED_LANGUAGES.includes(prefix)) {
+            return prefix;
+        }
+    }
+
+    return 'en';
+}
+
+/**
+ * Synchronizes browser URL to include /${lang}/ without triggering page reload.
+ */
+export function syncLanguageUrl(lang, replace = false) {
+    if (!SUPPORTED_LANGUAGES.includes(lang)) return;
+
+    const pathSegments = window.location.pathname.split('/').filter(Boolean);
+    // Remove existing language segment if present
+    if (pathSegments.length > 0 && SUPPORTED_LANGUAGES.includes(pathSegments[0].toLowerCase())) {
+        pathSegments.shift();
+    }
+
+    const currentHash = window.location.hash || '';
+    const remainingPath = pathSegments.length > 0 ? pathSegments.join('/') + '/' : '';
+    const newPathname = `/${lang}/${remainingPath}`;
+    const newUrl = `${newPathname}${currentHash}`;
+
+    if (window.location.pathname + window.location.hash !== newUrl) {
+        if (replace) {
+            history.replaceState(null, '', newUrl);
+        } else {
+            history.pushState(null, '', newUrl);
+        }
+    }
+
+    document.documentElement.lang = lang;
+
+    // Update canonical link element
+    let canonical = document.querySelector('link[rel="canonical"]');
+    if (canonical) {
+        canonical.href = `https://orecalc.tech/${lang}/`;
+    }
+}
+
+/**
+ * Validates whether a pathname is a valid application route or language route.
+ */
+export function isValidRoute(pathName) {
+    if (!pathName || pathName === '/' || pathName === '/index.html' || pathName === '/404' || pathName === '/404.html') {
+        return true;
+    }
+    const pathSegments = pathName.split('/').filter(Boolean);
+    if (pathSegments.length === 0) return true;
+
+    // Check if first segment is a supported language (e.g., /en, /de, /tr)
+    if (SUPPORTED_LANGUAGES.includes(pathSegments[0].toLowerCase())) {
+        if (pathSegments.length === 1) return true; // /de or /de/
+        const subRoute = pathSegments[1].toLowerCase();
+        const validSubRoutes = ['privacy', 'terms', 'licenses', 'planner', 'income', 'equipment', 'settings', 'home', '404'];
+        if (validSubRoutes.includes(subRoute)) return true;
+    }
+
+    // Static root routes
+    const validRootRoutes = ['privacy', 'terms', 'licenses'];
+    if (pathSegments.length === 1 && validRootRoutes.includes(pathSegments[0].toLowerCase())) {
+        return true;
+    }
+
+    return false;
+}

--- a/js/i18n/translator.js
+++ b/js/i18n/translator.js
@@ -7,7 +7,7 @@ export async function loadTranslations(language) {
         state.uiSettings.language = 'en';
     }
     try {
-        const response = await fetch(`js/i18n/${language}.json`);
+        const response = await fetch(`/js/i18n/${language}.json`);
         if (!response.ok) {
             throw new Error(`Failed to load translation file for ${language}`);
         }

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,17 +1,58 @@
+map $http_accept_language $lang_prefix {
+    default en;
+    ~*^de de;
+    ~*^tr tr;
+}
+
 server {
     listen 80;
     server_name localhost;
+    root /usr/share/nginx/html;
+    index index.html index.htm;
     absolute_redirect off;
 
+    # Rewrite language-prefixed static asset requests (/de/assets/..., /de/js/..., /de/css/...) to root assets
+    location ~ ^/(en|de|tr)/(assets|js|css|partials|licenses)/ {
+        rewrite ^/(en|de|tr)/(.*)$ /$2 last;
+    }
+
+    # Root redirect based on Accept-Language
+    location = / {
+        return 302 /$lang_prefix/;
+    }
+
+    # 301 Redirects for legacy legal URLs to clean uniform routes
+    location = /privacy { return 301 /en/privacy; }
+    location = /privacy.html { return 301 /en/privacy; }
+    location = /privacy/de { return 301 /de/privacy; }
+    location = /privacy/de/ { return 301 /de/privacy; }
+
+    location = /terms { return 301 /en/terms; }
+    location = /terms.html { return 301 /en/terms; }
+    location = /terms/de { return 301 /de/terms; }
+    location = /terms/de/ { return 301 /de/terms; }
+
+    location = /licenses { return 301 /en/licenses; }
+    location = /licenses.html { return 301 /en/licenses; }
+
+    location /en/ {
+        try_files $uri $uri/ /en/index.html;
+    }
+
+    location /de/ {
+        try_files $uri $uri/ /de/index.html;
+    }
+
+    location /tr/ {
+        try_files $uri $uri/ /tr/index.html;
+    }
+
     location / {
-        root /usr/share/nginx/html;
-        index index.html index.htm;
-        try_files $uri.html $uri $uri/ =404;
+        try_files $uri.html $uri $uri/ /en/index.html;
     }
 
     error_page 404 /404.html;
     location = /404.html {
-        root /usr/share/nginx/html;
         internal;
     }
 }

--- a/partials/modals/bug-report.html
+++ b/partials/modals/bug-report.html
@@ -7,7 +7,7 @@
             </button>
         </div>
         <div class="modal-info-text text-left">
-            <p data-i18n="settings.bugReportInfo" data-i18n-args='{"link": "<a href=\"https://github.com/abhis-s/oreCalc/issues\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"theme-link\">GitHub Issues</a>"}'>
+            <p data-i18n="settings.bugReportInfo">
                 Alternatively, you can report the issue directly on our <a href="https://github.com/abhis-s/oreCalc/issues" target="_blank" rel="noopener noreferrer" class="theme-link">GitHub Issues</a> page.
             </p>
         </div>
@@ -47,7 +47,7 @@
                 </div>
             </div>
             <div class="privacy-notice push-top-5">
-                <p data-i18n="settings.bugReportPrivacyInfo" data-i18n-args='{"link": "<a href=\"#\" id=\"bug-report-privacy-link\" class=\"theme-link\">Privacy Policy</a>"}'>
+                <p data-i18n="settings.bugReportPrivacyInfo">
                     By submitting this report, you agree that your user data and the provided email address will be processed in accordance with our <a href="#" id="bug-report-privacy-link" class="theme-link">Privacy Policy</a>.
                 </p>
             </div>

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -309,9 +309,111 @@ async function build() {
         const esbuildQrCmd = `npx esbuild "${path.join(projectRoot, 'js/qr-code-styling.js')}" --minify --outfile="${path.join(jsDestDir, 'qr-code-styling.js')}"`;
         execSync(esbuildQrCmd, { stdio: verbose ? 'inherit' : 'ignore' });
         
-        // Write index.html
-        fs.writeFileSync(path.join(distDir, 'index.html'), indexHtml, 'utf8');
-        console.log(`Compiled and bundled index.html.`);
+        // Write index.html for root and each supported language route (/en/, /de/, /tr/)
+        const localesMap = { en: 'en_US', de: 'de_DE', tr: 'tr_TR' };
+        function getNestedValue(obj, keyPath) {
+            return keyPath.split('.').reduce((acc, part) => (acc && acc[part] !== undefined) ? acc[part] : undefined, obj);
+        }
+        function generateLocalizedHtml(baseHtml, lang) {
+            const i18nFilePath = path.join(projectRoot, `js/i18n/${lang}.json`);
+            if (!fs.existsSync(i18nFilePath)) {
+                return baseHtml;
+            }
+            const translations = JSON.parse(fs.readFileSync(i18nFilePath, 'utf8'));
+            const title = translations.app?.title || 'Clash of Clans Ore Calculator & Equipment Planner | OreCalc';
+            const description = translations.app?.description || '';
+            const locale = localesMap[lang] || `${lang}_${lang.toUpperCase()}`;
+            const url = `https://orecalc.tech/${lang}/`;
+
+            let html = baseHtml;
+            html = html.replace(/<html lang="[^"]*">/, `<html lang="${lang}">`);
+            html = html.replace(/<title[^>]*>.*?<\/title>/s, `<title data-i18n="app.title">${title}</title>`);
+            html = html.replace(/<meta name="description"\s+content="[^"]*">/s, `<meta name="description" content="${description}">`);
+            html = html.replace(/<link rel="canonical" href="[^"]*">/, `<link rel="canonical" href="${url}">`);
+            html = html.replace(/<meta property="og:title" content="[^"]*">/g, `<meta property="og:title" content="${title}">`);
+            html = html.replace(/<meta property="og:description"\s+content="[^"]*">/g, `<meta property="og:description" content="${description}">`);
+            html = html.replace(/<meta property="og:url" content="[^"]*">/g, `<meta property="og:url" content="${url}">`);
+            if (html.includes('<meta property="og:locale"')) {
+                html = html.replace(/<meta property="og:locale" content="[^"]*">/, `<meta property="og:locale" content="${locale}">`);
+            } else {
+                html = html.replace(/<meta property="og:type" content="website">/, `<meta property="og:type" content="website">\n    <meta property="og:locale" content="${locale}">`);
+            }
+            html = html.replace(/<meta property="twitter:title" content="[^"]*">/g, `<meta property="twitter:title" content="${title}">`);
+            html = html.replace(/<meta property="twitter:description"\s+content="[^"]*">/g, `<meta property="twitter:description" content="${description}">`);
+            html = html.replace(/<meta property="twitter:url" content="[^"]*">/g, `<meta property="twitter:url" content="${url}">`);
+            html = html.replace(/"description": "[^"]*"/, `"description": "${description.replace(/"/g, '\\"')}"`);
+            html = html.replace(/"url": "[^"]*"/, `"url": "${url}"`);
+
+            // Pre-render static body elements marked with data-i18n
+            html = html.replace(/<([a-z1-6]+)([^>]*?)\s+data-i18n="([^"]+)"([^>]*)>([\s\S]*?)<\/\1>/gi, (match, tagName, attrsBefore, key, attrsAfter, innerContent) => {
+                let val = getNestedValue(translations, key);
+                if (typeof val === 'string' && val.trim()) {
+                    if (key === 'settings.bugReportInfo') {
+                        val = val.replace('{link}', '<a href="https://github.com/abhis-s/oreCalc/issues" target="_blank" rel="noopener noreferrer" class="theme-link">GitHub Issues</a>');
+                    } else if (key === 'settings.bugReportPrivacyInfo') {
+                        const privacyText = getNestedValue(translations, 'settings.privacyPolicyText') || 'Privacy Policy';
+                        val = val.replace('{link}', `<a href="#" id="bug-report-privacy-link" class="theme-link">${privacyText}</a>`);
+                    }
+                    return `<${tagName}${attrsBefore} data-i18n="${key}"${attrsAfter}>${val}</${tagName}>`;
+                }
+                return match;
+            });
+
+            return html;
+        }
+
+        const supportedLanguages = ['en', 'de', 'tr'];
+        for (const lang of supportedLanguages) {
+            const langDir = path.join(distDir, lang);
+            if (!fs.existsSync(langDir)) {
+                fs.mkdirSync(langDir, { recursive: true });
+            }
+            const localizedHtml = generateLocalizedHtml(indexHtml, lang);
+            fs.writeFileSync(path.join(langDir, 'index.html'), localizedHtml, 'utf8');
+            console.log(`Generated localized route: dist/${lang}/index.html`);
+        }
+
+        // Build legal pages with uniform language subdirectories (/en/, /de/, /tr/)
+        const legalPages = [
+            { name: 'privacy', srcEn: 'privacy.html', srcDe: 'privacy/de/index.html' },
+            { name: 'terms', srcEn: 'terms.html', srcDe: 'terms/de/index.html' },
+            { name: 'licenses', srcEn: 'licenses.html', srcDe: 'licenses.html' }
+        ];
+
+        for (const page of legalPages) {
+            for (const lang of supportedLanguages) {
+                let srcFile = page.srcEn;
+                let canonicalUrl = `https://orecalc.tech/${lang}/${page.name}`;
+                
+                if (lang === 'de' && page.srcDe) {
+                    srcFile = page.srcDe;
+                } else if (lang === 'tr') {
+                    // Turkish uses English legal document with canonical link pointing to /en/page
+                    srcFile = page.srcEn;
+                    canonicalUrl = `https://orecalc.tech/en/${page.name}`;
+                }
+
+                const srcPath = path.join(projectRoot, srcFile);
+                if (!fs.existsSync(srcPath)) continue;
+
+                let html = fs.readFileSync(srcPath, 'utf8');
+
+                if (html.includes('<link rel="canonical"')) {
+                    html = html.replace(/<link rel="canonical" href="[^"]*">/, `<link rel="canonical" href="${canonicalUrl}">`);
+                } else {
+                    html = html.replace('</head>', `    <link rel="canonical" href="${canonicalUrl}">\n</head>`);
+                }
+
+                const pageDestDir = path.join(distDir, lang, page.name);
+                fs.mkdirSync(pageDestDir, { recursive: true });
+                fs.writeFileSync(path.join(pageDestDir, 'index.html'), html, 'utf8');
+                console.log(`Generated legal page route: dist/${lang}/${page.name}/index.html`);
+            }
+        }
+
+        const defaultHtml = generateLocalizedHtml(indexHtml, 'en');
+        fs.writeFileSync(path.join(distDir, 'index.html'), defaultHtml, 'utf8');
+        console.log(`Compiled and bundled index.html for root and language routes.`);
         
         const libsDestDir = path.join(distDir, 'js');
         const libsSource = path.join(projectRoot, 'node_modules/workbox-window/build/workbox-window.prod.umd.js');
@@ -422,7 +524,7 @@ async function build() {
         // 5. Replace CSS path in HTML
         console.log('\n--- Updating HTML for production ---');
         await replaceInFile({
-            files: path.join(distDir, 'index.html'),
+            files: [path.join(distDir, 'index.html'), path.join(distDir, '**/index.html')],
             from: /css\/main\.css/g,
             to: 'css/main.min.css',
         });

--- a/scripts/dev/start-dev-server.js
+++ b/scripts/dev/start-dev-server.js
@@ -77,6 +77,122 @@ if (fs.existsSync(partialsDir)) {
 
 const openBrowser = process.env.OPEN_BROWSER !== 'false' && !process.argv.includes('--no-open');
 
+const localesMap = { en: 'en_US', de: 'de_DE', tr: 'tr_TR' };
+function getNestedValue(obj, keyPath) {
+    return keyPath.split('.').reduce((acc, part) => (acc && acc[part] !== undefined) ? acc[part] : undefined, obj);
+}
+function generateLocalizedHtml(baseHtml, lang) {
+    const i18nFilePath = path.join(process.cwd(), `js/i18n/${lang}.json`);
+    if (!fs.existsSync(i18nFilePath)) {
+        return baseHtml;
+    }
+    const translations = JSON.parse(fs.readFileSync(i18nFilePath, 'utf8'));
+    const title = translations.app?.title || 'Clash of Clans Ore Calculator & Equipment Planner | OreCalc';
+    const description = translations.app?.description || '';
+    const locale = localesMap[lang] || `${lang}_${lang.toUpperCase()}`;
+    const url = `https://orecalc.tech/${lang}/`;
+
+    let html = baseHtml;
+    html = html.replace(/<html lang="[^"]*">/, `<html lang="${lang}">`);
+    html = html.replace(/<title[^>]*>.*?<\/title>/s, `<title data-i18n="app.title">${title}</title>`);
+    html = html.replace(/<meta name="description"\s+content="[^"]*">/s, `<meta name="description" content="${description}">`);
+    html = html.replace(/<link rel="canonical" href="[^"]*">/, `<link rel="canonical" href="${url}">`);
+    html = html.replace(/<meta property="og:title" content="[^"]*">/g, `<meta property="og:title" content="${title}">`);
+    html = html.replace(/<meta property="og:description"\s+content="[^"]*">/g, `<meta property="og:description" content="${description}">`);
+    html = html.replace(/<meta property="og:url" content="[^"]*">/g, `<meta property="og:url" content="${url}">`);
+    if (html.includes('<meta property="og:locale"')) {
+        html = html.replace(/<meta property="og:locale" content="[^"]*">/, `<meta property="og:locale" content="${locale}">`);
+    } else {
+        html = html.replace(/<meta property="og:type" content="website">/, `<meta property="og:type" content="website">\n    <meta property="og:locale" content="${locale}">`);
+    }
+    html = html.replace(/<meta property="twitter:title" content="[^"]*">/g, `<meta property="twitter:title" content="${title}">`);
+    html = html.replace(/<meta property="twitter:description"\s+content="[^"]*">/g, `<meta property="twitter:description" content="${description}">`);
+    html = html.replace(/<meta property="twitter:url" content="[^"]*">/g, `<meta property="twitter:url" content="${url}">`);
+    html = html.replace(/"description": "[^"]*"/, `"description": "${description.replace(/"/g, '\\"')}"`);
+    html = html.replace(/"url": "[^"]*"/, `"url": "${url}"`);
+
+    // Pre-render static body elements marked with data-i18n
+    html = html.replace(/<([a-z1-6]+)([^>]*?)\s+data-i18n="([^"]+)"([^>]*)>([\s\S]*?)<\/\1>/gi, (match, tagName, attrsBefore, key, attrsAfter, innerContent) => {
+        let val = getNestedValue(translations, key);
+        if (typeof val === 'string' && val.trim()) {
+            if (key === 'settings.bugReportInfo') {
+                val = val.replace('{link}', '<a href="https://github.com/abhis-s/oreCalc/issues" target="_blank" rel="noopener noreferrer" class="theme-link">GitHub Issues</a>');
+            } else if (key === 'settings.bugReportPrivacyInfo') {
+                const privacyText = getNestedValue(translations, 'settings.privacyPolicyText') || 'Privacy Policy';
+                val = val.replace('{link}', `<a href="#" id="bug-report-privacy-link" class="theme-link">${privacyText}</a>`);
+            }
+            return `<${tagName}${attrsBefore} data-i18n="${key}"${attrsAfter}>${val}</${tagName}>`;
+        }
+        return match;
+    });
+
+    return html;
+}
+
+function getCompiledIndexHtml(lang = 'en') {
+    if (!cachedHtml) {
+        const indexPath = path.join(process.cwd(), 'index.html');
+        let content = fs.readFileSync(indexPath, 'utf8');
+        content = processHtmlIncludes(content, process.cwd());
+        
+        const packageJson = require(path.join(process.cwd(), 'package.json'));
+        let gitHash = 'dev';
+        try {
+            const { execSync } = require('child_process');
+            gitHash = execSync('git rev-parse --short HEAD').toString().trim();
+        } catch (e) {
+            // fallback
+        }
+        const appVersion = `${packageJson.version}+${gitHash}`;
+
+        let commitsSinceTag = [];
+        try {
+            const { execSync } = require('child_process');
+            let lastTag = '';
+            try {
+                lastTag = execSync('git describe --tags --abbrev=0').toString().trim();
+            } catch (e) {
+                // No tag exists
+            }
+
+            const range = lastTag ? `${lastTag}..HEAD` : '';
+            const logCmd = range 
+                ? `git log ${range} --pretty=format:"%h|%at|%s"` 
+                : `git log -n 50 --pretty=format:"%h|%at|%s"`;
+            const logOutput = execSync(logCmd).toString().trim();
+
+            if (logOutput) {
+                const lines = logOutput.split('\n');
+                const commits = lines.map(line => {
+                    const parts = line.split('|');
+                    const hash = parts[0];
+                    const timestamp = parseInt(parts[1], 10) * 1000;
+                    const subject = parts.slice(2).join('|');
+                    return { hash, timestamp, subject };
+                });
+
+                const oneWeekAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
+                const commitsInLastWeek = commits.filter(c => c.timestamp >= oneWeekAgo);
+                
+                let selectedCommits = [];
+                if (commitsInLastWeek.length >= 3) {
+                    selectedCommits = commitsInLastWeek;
+                } else {
+                    selectedCommits = commits.slice(0, Math.min(3, commits.length));
+                }
+                commitsSinceTag = selectedCommits.map(c => ({ hash: c.hash, subject: c.subject }));
+            }
+        } catch (error) {
+            // fallback
+        }
+
+        // Inject global environment context into index.html head for runtime API endpoint resolving
+        content = content.replace('<head>', `<head>\n    <script>window.__ENV__ = { VITE_API_BASE_URL: "${devApiBaseUrl}", APP_VERSION: "${appVersion}", COMMITS_SINCE_TAG: ${JSON.stringify(commitsSinceTag)} };</script>`);
+        cachedHtml = content;
+    }
+    return generateLocalizedHtml(cachedHtml, lang);
+}
+
 const params = {
     port: 8080,
     host: "0.0.0.0",
@@ -86,10 +202,16 @@ const params = {
     wait: 1000,
     logLevel: 2,
     middleware: [
-        // Custom middleware to intercept index.html requests, dynamically inject environment configs,
-        // and serve the processed HTML directly from cache or compile it on the fly.
         function(req, res, next) {
-            // Parse URL safely to extract pathname and query parameters
+            // Strip language prefix (/en/, /de/, /tr/) for static asset requests if present
+            const langPrefixMatch = req.url.match(/^\/(en|de|tr)\/(.+)$/);
+            if (langPrefixMatch) {
+                const potentialAssetPath = path.join(process.cwd(), langPrefixMatch[2]);
+                if (fs.existsSync(potentialAssetPath) && fs.statSync(potentialAssetPath).isFile()) {
+                    req.url = '/' + langPrefixMatch[2];
+                }
+            }
+
             let pathname = req.url;
             let query = '';
             const qIdx = req.url.indexOf('?');
@@ -98,69 +220,22 @@ const params = {
                 query = req.url.substring(qIdx);
             }
 
-            if (pathname === '/' || pathname === '/index.html') {
-                if (!cachedHtml) {
-                    const indexPath = path.join(process.cwd(), 'index.html');
-                    let content = fs.readFileSync(indexPath, 'utf8');
-                    content = processHtmlIncludes(content, process.cwd());
-                    
-                    const packageJson = require(path.join(process.cwd(), 'package.json'));
-                    let gitHash = 'dev';
-                    try {
-                        const { execSync } = require('child_process');
-                        gitHash = execSync('git rev-parse --short HEAD').toString().trim();
-                    } catch (e) {
-                        // fallback
-                    }
-                    const appVersion = `${packageJson.version}+${gitHash}`;
+            const isRoot = pathname === '/' || pathname === '/index.html';
+            const isExactLangNoSlash = ['/en', '/de', '/tr'].includes(pathname);
+            const langMatch = pathname.match(/^\/(en|de|tr)(\/|$)/);
 
-                    let commitsSinceTag = [];
-                    try {
-                        const { execSync } = require('child_process');
-                        let lastTag = '';
-                        try {
-                            lastTag = execSync('git describe --tags --abbrev=0').toString().trim();
-                        } catch (e) {
-                            // No tag exists
-                        }
-
-                        const range = lastTag ? `${lastTag}..HEAD` : '';
-                        const logCmd = range 
-                            ? `git log ${range} --pretty=format:"%h|%at|%s"` 
-                            : `git log -n 50 --pretty=format:"%h|%at|%s"`;
-                        const logOutput = execSync(logCmd).toString().trim();
-
-                        if (logOutput) {
-                            const lines = logOutput.split('\n');
-                            const commits = lines.map(line => {
-                                const parts = line.split('|');
-                                const hash = parts[0];
-                                const timestamp = parseInt(parts[1], 10) * 1000;
-                                const subject = parts.slice(2).join('|');
-                                return { hash, timestamp, subject };
-                            });
-
-                            const oneWeekAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
-                            const commitsInLastWeek = commits.filter(c => c.timestamp >= oneWeekAgo);
-                            
-                            let selectedCommits = [];
-                            if (commitsInLastWeek.length >= 3) {
-                                selectedCommits = commitsInLastWeek;
-                            } else {
-                                selectedCommits = commits.slice(0, Math.min(3, commits.length));
-                            }
-                            commitsSinceTag = selectedCommits.map(c => ({ hash: c.hash, subject: c.subject }));
-                        }
-                    } catch (error) {
-                        // fallback
-                    }
-
-                    // Inject global environment context into index.html head for runtime API endpoint resolving
-                    content = content.replace('<head>', `<head>\n    <script>window.__ENV__ = { VITE_API_BASE_URL: "${devApiBaseUrl}", APP_VERSION: "${appVersion}", COMMITS_SINCE_TAG: ${JSON.stringify(commitsSinceTag)} };</script>`);
-                    cachedHtml = content;
-                }
+            if (isExactLangNoSlash) {
+                res.writeHead(301, { Location: `${pathname}/${query}` });
+                return res.end();
+            } else if (isRoot) {
+                const html = getCompiledIndexHtml('en');
                 res.setHeader('Content-Type', 'text/html');
-                res.end(cachedHtml);
+                res.end(html);
+            } else if (langMatch) {
+                const lang = langMatch[1];
+                const html = getCompiledIndexHtml(lang);
+                res.setHeader('Content-Type', 'text/html');
+                res.end(html);
             } else if (['/privacy', '/terms', '/licenses', '/404'].includes(pathname)) {
                 // Serve the corresponding static html file cleanly
                 const filePath = path.join(process.cwd(), `${pathname.substring(1)}.html`);

--- a/service-worker-src.js
+++ b/service-worker-src.js
@@ -106,9 +106,39 @@ registerRoute(
     })
 );
 
+const navigationStrategy = new NetworkFirst({
+    cacheName: 'navigation-cache',
+    plugins: [new CacheableResponsePlugin({ statuses: [200] })]
+});
+
 registerRoute(
-    ({ request }) => request.mode === 'navigate',
-    new StaleWhileRevalidate({ cacheName: 'navigation-cache' })
+    ({ request, url }) => request.mode === 'navigate' && !url.pathname.includes('/api/'),
+    async (options) => {
+        try {
+            const response = await navigationStrategy.handle(options);
+            if (response) return response;
+        } catch (error) {
+            // Network failed or offline
+        }
+
+        const pathname = options.url.pathname;
+        const segments = pathname.split('/').filter(Boolean);
+        let lang = 'en';
+        if (segments.length > 0 && ['en', 'de', 'tr'].includes(segments[0].toLowerCase())) {
+            lang = segments[0].toLowerCase();
+        }
+
+        const localizedKey = precacheController.getCacheKeyForURL(`/${lang}/index.html`) 
+                          || precacheController.getCacheKeyForURL('/index.html');
+
+        if (localizedKey) {
+            const cache = await caches.open(workbox.core.cacheNames.precache);
+            const cachedResponse = await cache.match(localizedKey);
+            if (cachedResponse) return cachedResponse;
+        }
+
+        return Response.error();
+    }
 );
 
 // Cache Clash of Clans API assets (like league icons)

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -6,50 +6,77 @@
               http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 
   <url>
-    <loc>https://orecalc.tech/</loc>
+    <loc>https://orecalc.tech/en/</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://orecalc.tech/en/" />
+    <xhtml:link rel="alternate" hreflang="de" href="https://orecalc.tech/de/" />
+    <xhtml:link rel="alternate" hreflang="tr" href="https://orecalc.tech/tr/" />
     <lastmod>2026-07-23T00:00:00+00:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
 
   <url>
-    <loc>https://orecalc.tech/privacy</loc>
-    <xhtml:link rel="alternate" hreflang="en" href="https://orecalc.tech/privacy" />
-    <xhtml:link rel="alternate" hreflang="de" href="https://orecalc.tech/privacy/de" />
+    <loc>https://orecalc.tech/de/</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://orecalc.tech/en/" />
+    <xhtml:link rel="alternate" hreflang="de" href="https://orecalc.tech/de/" />
+    <xhtml:link rel="alternate" hreflang="tr" href="https://orecalc.tech/tr/" />
+    <lastmod>2026-07-23T00:00:00+00:00</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+
+  <url>
+    <loc>https://orecalc.tech/tr/</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://orecalc.tech/en/" />
+    <xhtml:link rel="alternate" hreflang="de" href="https://orecalc.tech/de/" />
+    <xhtml:link rel="alternate" hreflang="tr" href="https://orecalc.tech/tr/" />
+    <lastmod>2026-07-23T00:00:00+00:00</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+
+  <url>
+    <loc>https://orecalc.tech/en/privacy</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://orecalc.tech/en/privacy" />
+    <xhtml:link rel="alternate" hreflang="de" href="https://orecalc.tech/de/privacy" />
+    <xhtml:link rel="alternate" hreflang="tr" href="https://orecalc.tech/en/privacy" />
     <lastmod>2026-07-23T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
 
   <url>
-    <loc>https://orecalc.tech/privacy/de</loc>
-    <xhtml:link rel="alternate" hreflang="en" href="https://orecalc.tech/privacy" />
-    <xhtml:link rel="alternate" hreflang="de" href="https://orecalc.tech/privacy/de" />
+    <loc>https://orecalc.tech/de/privacy</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://orecalc.tech/en/privacy" />
+    <xhtml:link rel="alternate" hreflang="de" href="https://orecalc.tech/de/privacy" />
+    <xhtml:link rel="alternate" hreflang="tr" href="https://orecalc.tech/en/privacy" />
     <lastmod>2026-07-23T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
 
   <url>
-    <loc>https://orecalc.tech/terms</loc>
-    <xhtml:link rel="alternate" hreflang="en" href="https://orecalc.tech/terms" />
-    <xhtml:link rel="alternate" hreflang="de" href="https://orecalc.tech/terms/de" />
+    <loc>https://orecalc.tech/en/terms</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://orecalc.tech/en/terms" />
+    <xhtml:link rel="alternate" hreflang="de" href="https://orecalc.tech/de/terms" />
+    <xhtml:link rel="alternate" hreflang="tr" href="https://orecalc.tech/en/terms" />
     <lastmod>2026-07-23T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
 
   <url>
-    <loc>https://orecalc.tech/terms/de</loc>
-    <xhtml:link rel="alternate" hreflang="en" href="https://orecalc.tech/terms" />
-    <xhtml:link rel="alternate" hreflang="de" href="https://orecalc.tech/terms/de" />
+    <loc>https://orecalc.tech/de/terms</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://orecalc.tech/en/terms" />
+    <xhtml:link rel="alternate" hreflang="de" href="https://orecalc.tech/de/terms" />
+    <xhtml:link rel="alternate" hreflang="tr" href="https://orecalc.tech/en/terms" />
     <lastmod>2026-07-23T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
 
   <url>
-    <loc>https://orecalc.tech/licenses</loc>
+    <loc>https://orecalc.tech/en/licenses</loc>
     <lastmod>2026-07-23T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.3</priority>


### PR DESCRIPTION
- Add languageRouter.js for URL detection, history sync, and route validation
- Preserve language route prefixes in pushState events across navigation components
- Integrate syncLanguageUrl into settings and welcome modals
- Implement SSG localized pre-rendering in build.js and start-dev-server.js
- Update nginx.conf with 302 redirects, asset rewrites, and 301 legal rules
- Add locale-aware offline index precache fallback in service-worker-src.js
- Add explicit language URLs and reciprocal hreflang tags to sitemap and HTML
- Update 404.html return links to preserve language subdirectories
- Update translator.js to fetch i18n JSON files via absolute paths
- Remove inline data-i18n-args from bug-report modal